### PR TITLE
Fix the navbar-toggle button

### DIFF
--- a/View/Helper/BootstrapNavbarHelper.php
+++ b/View/Helper/BootstrapNavbarHelper.php
@@ -417,14 +417,15 @@ class BootstrapNavbarHelper extends Helper {
         $inner = implode('', $htmls) ;
         
         if ($this->responsive) {
-            $button = $this->Html->tag('a', 
+            $button = $this->Html->tag('button', 
                 implode('', array(
+                    $this->Html->tag('span', __('Toggle navigation'), array('class' => 'sr-only')),
                     $this->Html->tag('span', '', array('class' => 'icon-bar')),
                     $this->Html->tag('span', '', array('class' => 'icon-bar')),
                     $this->Html->tag('span', '', array('class' => 'icon-bar'))
                 )),
                 array(
-                    'class' => 'btn btn-navbar',
+                    'class' => 'navbar-toggle',
                     'data-toggle' => 'collapse',
                     'data-target' => '.navbar-collapse'
                 )


### PR DESCRIPTION
```
Fix the class. The button wasn't being displayed with the old class.

Add the "Toggle navigation" text for screen readers

Even though it seems to work fine with the "a" tag, change the tag to
"button", just to be like the doc.
```

Reference: http://getbootstrap.com/components/#navbar-default
