### PR TITLE
Fix bug with inputs where prepend and append can't be combined

### DIFF
--- a/View/Helper/BootstrapFormHelper.php
+++ b/View/Helper/BootstrapFormHelper.php
@@ -271,7 +271,7 @@ class BootstrapFormHelper extends FormHelper {
             }
         }
         if ($append) {
-            $beforeClass[] = 'input-group' ;
+            if (!$prepend) $beforeClass[] = 'input-group' ;
             if (is_string($append)) {
                 $between = '<span class="input-group-'.($this->_matchButton($append) ? 'btn' : 'addon').'">'.$append.'</span>'.$between ;
             }


### PR DESCRIPTION
When using the FormHelper to create an input with the `prepend` and `append` key at the same time (additional html before and after the input control), it gets wrapped in two `<div class="input-group">`. This destroys the layout, at least in horizontal forms. 

My fix is quite simple - I add an additional check for this case. Using `array_unique` on the `$beforeClass` array might be an alternative solution, but I did not check this. 

Best regards
Markus Bauer